### PR TITLE
Minor changes

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #define size_of_attribute(Struct, Attribute) sizeof(((Struct *)0)->Attribute)
 
@@ -39,8 +40,8 @@ typedef enum StatementType_t StatementType;
 enum NodeType_t { NODE_INTERNAL, NODE_LEAF };
 typedef enum NodeType_t NodeType;
 
-const uint32_t COLUMN_USERNAME_SIZE = 32;
-const uint32_t COLUMN_EMAIL_SIZE = 255;
+#define COLUMN_USERNAME_SIZE 32
+#define COLUMN_EMAIL_SIZE 255
 struct Row_t {
   uint32_t id;
   char username[COLUMN_USERNAME_SIZE + 1];
@@ -63,7 +64,7 @@ const uint32_t EMAIL_OFFSET = USERNAME_OFFSET + USERNAME_SIZE;
 const uint32_t ROW_SIZE = ID_SIZE + USERNAME_SIZE + EMAIL_SIZE;
 
 const uint32_t PAGE_SIZE = 4096;
-const uint32_t TABLE_MAX_PAGES = 100;
+#define TABLE_MAX_PAGES 100
 
 struct Pager_t {
   int file_descriptor;
@@ -636,4 +637,11 @@ int main(int argc, char *argv[]) {
       break;
     }
   }
+
+  free(input_buffer);
+  for (int i = 0; i < TABLE_MAX_PAGES; i++) {
+    free(table->pager->pages[i]);
+  }
+  free(table -> pager);
+  free(table);
 }


### PR DESCRIPTION
- add missing `<stdint>` in `main.c` which avoids *`uint32_t` not found* on Linux
- add missing `free()` to avoid some memory leaks
- use `#define` instead of `const uint32_t` to create compile-time constants (error in GCC)